### PR TITLE
fix masking bug in d2d_DrawScanLine

### DIFF
--- a/src/miniGL/draw2d.c
+++ b/src/miniGL/draw2d.c
@@ -164,10 +164,10 @@ void d2d_DrawScanLine(int _x0, int _y0, int _x1, int _y1) {
     }
 
     // last aligned byte
-    uint8_t mask = ~masks[unalignedPixelsRight];
+    uint8_t mask = ~masks[unalignedPixelsRight + 1];
     // if there's just one byte on this line, mask the mask
     if(firstAlignedX == lastAlignedX ){
-        mask ^= masks[unalignedPixelsLeft+1];
+        mask ^= masks[unalignedPixelsLeft];
     }
     *pixelData &= mask;
     *pixelData |= ditheredByte & ~mask;


### PR DESCRIPTION
Hey Matt! When working on http://www.pouet.net/prod.php?which=71545 I started off using the implementation of `d2d_DrawScanLine()` and found a bug in the masking code. This patch back-ports the fix to your project. Here's the actual implementation I ended up using in the project which is backed with snapshot-based unit tests (not that I assume values to be clamped already):
```
static void HLINE_NAME(GColorL1Byte *pixelData, int32_t y, int32_t x1, int32_t x2, uint8_t ditheredByte) {
  if (x1 > x2) {
    return;
  }

  // start offset
  pixelData += y * SCREEN_NUM_BYTES_PER_LINE + x1 / 8;

  // masks for (optionally first and) last byte of line
  const int32_t firstAlignedX = x1 & 0b1111111111111000;
  const int32_t lastAlignedX =  x2 & 0b1111111111111000;
  const int32_t unalignedPixelsLeft = x1 % 8;
  const int32_t unalignedPixelsRight = x2 % 8;

  // actual loop, based on bytes not individual pixels
  int32_t x = x1;
  if (firstAlignedX < lastAlignedX) {
    // first aligned byte
    if (unalignedPixelsLeft) {
      const uint8_t mask = hb2d_hline_masks[unalignedPixelsLeft];
      pixelData->pixels HLINE_PIXEL_OP (ditheredByte HLINE_MASK_OP mask);
      pixelData++;
      x += 8 - unalignedPixelsLeft;
    }

    // all but the last aligned byte
    while (x < lastAlignedX) {
      pixelData->pixels HLINE_PIXEL_OP ditheredByte;
      pixelData++;
      x += 8;
    }
  }

  // last aligned byte
  uint8_t mask = ~hb2d_hline_masks[unalignedPixelsRight + 1];
  // if there's just one byte on this line, mask the mask
  if (firstAlignedX == lastAlignedX) {
    mask ^= hb2d_hline_masks[unalignedPixelsLeft];
  }
  pixelData->pixels HLINE_PIXEL_OP (ditheredByte HLINE_MASK_OP mask);
}
```
to be used with
```
// declare _xor_line(...)
#define HLINE_PIXEL_OP ^=
#define HLINE_MASK_OP &~
#define HLINE_NAME _xor_hline
#include "_DemoGraphics_hline_inc.h"

// declare _or_line(...)
#define HLINE_PIXEL_OP |=
#define HLINE_MASK_OP &~
#define HLINE_NAME _or_hline
#include "_DemoGraphics_hline_inc.h"

// declare _and_line(...)
#define HLINE_PIXEL_OP &=
#define HLINE_MASK_OP |
#define HLINE_NAME _and_hline
#include "_DemoGraphics_hline_inc.h"
```